### PR TITLE
fix: prefer_64_bit is deprecated

### DIFF
--- a/kr.rb
+++ b/kr.rb
@@ -35,7 +35,7 @@ class Kr < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["GOOS"] = "darwin"
-    ENV["GOARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386"
+    ENV["GOARCH"] = Hardware::CPU.is_64_bit? ? "amd64" : "386"
 
     dir = buildpath/"src/github.com/kryptco/kr"
     dir.install buildpath.children


### PR DESCRIPTION
See https://github.com/Homebrew/brew/commit/170c5493a4e3628ed77137215a9ed6328e1a17c8#diff-1c1e64ec9fa3342388d0ddb7a9607eca 
and
https://github.com/dart-lang/homebrew-dart/issues/58

This should close #8.