### PR TITLE
fixes `brew install kr --HEAD`

### DIFF
--- a/kr.rb
+++ b/kr.rb
@@ -28,11 +28,11 @@ class Kr < Formula
   depends_on xcode: :build if MacOS.version >= "10.12"
 
   def install
-    ENV["GOPATH"] = buildpath
+    ENV["GOPATH"] = buildpath/"GOPATH"
     ENV["GOOS"] = "darwin"
     ENV["GOARCH"] = Hardware::CPU.is_64_bit? ? "amd64" : "386"
 
-    dir = buildpath/"src/github.com/kryptco/kr"
+    dir = buildpath/"GOPATH/src/github.com/kryptco/kr"
     dir.install buildpath.children
 
     mkdir_p ENV["HOME"]
@@ -41,7 +41,7 @@ class Kr < Formula
     ENV["PATH"] = ENV["HOME"] + "/Library/Caches/Homebrew/cargo_cache/bin" + ":" + ENV["PATH"]
     ENV["CARGO_HOME"] = ENV["HOME"] + "/.cargo"
 
-    cd "src/github.com/kryptco/kr" do
+    cd buildpath/"GOPATH/src/github.com/kryptco/kr" do
       old_prefix = ENV["PREFIX"]
       ENV["PREFIX"] = prefix
       system "make", "install"


### PR DESCRIPTION
build script wasn't expecting `src` dir to be present and was failing due to recursion:
Errno::EINVAL: Invalid argument @ rb_file_s_rename - (/private/tmp/kr-20210626-35843-q7v1f3/src, /private/tmp/kr-20210626-35843-q7v1f3/src/github.com/kryptco/kr/src)